### PR TITLE
add tini to start server in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ RUN cargo build --release
 
 FROM alpine:3.11
 
+RUN apk add --no-cache tini
+
 COPY --from=builder \
     /home/rust/src/target/x86_64-unknown-linux-musl/release/slp-server-rust \
     /usr/local/bin/
 
-ENTRYPOINT ["slp-server-rust"]
+ENTRYPOINT ["/sbin/tini", "slp-server-rust"]


### PR DESCRIPTION
add tini for docker entrypoint

by the way, could we have pre-built image in docker-hub? so everyone can easily start server