### PR TITLE
Fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ekidd/rust-musl-builder:1.44.0 AS BUILDER
+FROM ekidd/rust-musl-builder:1.49.0 AS BUILDER
 
 ADD --chown=rust:rust . ./
 


### PR DESCRIPTION
The build of master is failing due to the following errors. They can be resolved by upgrading Rust/the `ekidd/rust-musl-builder` image. Fixes https://github.com/spacemeowx2/slp-server-rust/issues/26

```
   Compiling bson v1.1.0
error[E0658]: use of unstable library feature 'str_strip': newly added
  --> /home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/async-graphql-parser-1.18.1/src/types/mod.rs:65:53
   |
65 |         let (nullable, ty) = if let Some(rest) = ty.strip_suffix('!') {
   |                                                     ^^^^^^^^^^^^
   |
   = note: see issue #67302 <https://github.com/rust-lang/rust/issues/67302> for more information

error[E0658]: use of unstable library feature 'str_strip': newly added
  --> /home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/async-graphql-parser-1.18.1/src/types/mod.rs:72:40
   |
72 |             base: if let Some(ty) = ty.strip_prefix('[') {
   |                                        ^^^^^^^^^^^^
   |
   = note: see issue #67302 <https://github.com/rust-lang/rust/issues/67302> for more information

error[E0658]: use of unstable library feature 'str_strip': newly added
  --> /home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/async-graphql-parser-1.18.1/src/types/mod.rs:73:54
   |
73 |                 BaseType::List(Box::new(Self::new(ty.strip_suffix(']')?)?))
   |                                                      ^^^^^^^^^^^^
   |
   = note: see issue #67302 <https://github.com/rust-lang/rust/issues/67302> for more information

error[E0658]: use of unstable library feature 'option_zip'
  --> /home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/async-graphql-parser-1.18.1/src/types/executable.rs:29:26
   |
29 |                         .zip(op.node.name.as_ref())
   |                          ^^^
   |
   = note: see issue #70086 <https://github.com/rust-lang/rust/issues/70086> for more information

error[E0658]: use of unstable library feature 'str_strip': newly added
  --> /home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/async-graphql-parser-1.18.1/src/types/mod.rs:65:53
   |
65 |         let (nullable, ty) = if let Some(rest) = ty.strip_suffix('!') {
   |                                                     ^^^^^^^^^^^^
   |
   = note: see issue #67302 <https://github.com/rust-lang/rust/issues/67302> for more information

error[E0658]: use of unstable library feature 'str_strip': newly added
  --> /home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/async-graphql-parser-1.18.1/src/types/mod.rs:72:40
   |
72 |             base: if let Some(ty) = ty.strip_prefix('[') {
   |                                        ^^^^^^^^^^^^
   |
   = note: see issue #67302 <https://github.com/rust-lang/rust/issues/67302> for more information

error[E0658]: use of unstable library feature 'str_strip': newly added
  --> /home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/async-graphql-parser-1.18.1/src/types/mod.rs:73:54
   |
73 |                 BaseType::List(Box::new(Self::new(ty.strip_suffix(']')?)?))
   |                                                      ^^^^^^^^^^^^
   |
   = note: see issue #67302 <https://github.com/rust-lang/rust/issues/67302> for more information

error[E0658]: use of unstable library feature 'option_zip'
  --> /home/rust/.cargo/registry/src/github.com-1ecc6299db9ec823/async-graphql-parser-1.18.1/src/types/executable.rs:29:26
   |
29 |                         .zip(op.node.name.as_ref())
   |                          ^^^
   |
   = note: see issue #70086 <https://github.com/rust-lang/rust/issues/70086> for more information

error: aborting due to 4 previous errors

For more information about this error, try `rustc --explain E0658`.
error: could not compile `async-graphql-parser`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: aborting due to 4 previous errors

For more information about this error, try `rustc --explain E0658`.
error: could not compile `async-graphql-parser`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
The command '/bin/sh -c cargo build --release' returned a non-zero code: 101
```
